### PR TITLE
feat: add admin user management page with bulk actions

### DIFF
--- a/apps/api/Controllers/AdminController.cs
+++ b/apps/api/Controllers/AdminController.cs
@@ -69,7 +69,7 @@ public class AdminController : Controller
         await _context.SaveChangesAsync();
 
         TempData["Success"] = $"Promoted {target.Email} to admin.";
-        return RedirectToAction(nameof(Users));
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpPost("demote/{id}")]

--- a/apps/api/Controllers/Api/AuthController.cs
+++ b/apps/api/Controllers/Api/AuthController.cs
@@ -30,9 +30,20 @@ public class AuthController : Controller
     [Consumes("application/json")]
     public async Task<IActionResult> RegisterApi(RegisterRequest dto)
     {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Validation failed",
+                Status = StatusCodes.Status400BadRequest,
+                Detail = string.Join(", ", ModelState.Values
+                    .SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage))
+            });
+        }
+
         var email = (dto.Email ?? "").Trim().ToLowerInvariant();
         var password = (dto.Password ?? "").Trim();
-
 
         if (await _context.Users.AsNoTracking().AnyAsync(u => u.Email == email))
             return Conflict(new ProblemDetails


### PR DESCRIPTION
This PR adds a comprehensive user management page for admins.

## Features
- View all users in a table format with search
- Real-time search by email
- User statistics dashboard showing:
  - Total users count
  - Number of admins
  - Number of Google-authenticated users
- Bulk actions:
  - Delete selected users
  - Promote users to admin
  - Remove admin role from users
- User details showing:
  - Email
  - Admin status badge
  - Google account badge
  - Join date
  - Avatar with email initial

## Technical Details
- New  for type-safe view data
- AdminController with:
  - GET /admin -> redirects to /admin/users
  - GET /admin/users -> shows user management page
  - POST endpoints for bulk actions
- Tailwind styling with responsive design
- JavaScript for real-time search and bulk actions
- Admin authorization checks
- Google integration preserved
- Full support for mixed authentication (Google and password)

## Testing
To test:
1. Login as an admin
2. Navigate to /admin or /admin/users
3. Try searching for users
4. Test bulk actions:
   - Select multiple users
   - Try each bulk action
   - Verify changes in database

Closes #48